### PR TITLE
Added Scheduled Commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "chalk": "^1.1.3",
     "commander": "2.9.x",
     "dot": "^1.0.3",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "later": "1.2.x"
   },
   "devDependencies": {
     "babel-cli": ">=6.7 <=7.0",

--- a/src/Cli.js
+++ b/src/Cli.js
@@ -1,6 +1,7 @@
 import './Output'
 import './MakeCommandCommand'
 import './TinkerCommand'
+import './ScheduleCommand'
 
 import program from 'commander'
 
@@ -14,6 +15,7 @@ export class Cli {
 		this.output = new Output
 		this.register(MakeCommandCommand)
 		this.register(TinkerCommand)
+		this.register(ScheduleCommand)
 	}
 
 	async run(args = process.argv) {

--- a/src/Cli.js
+++ b/src/Cli.js
@@ -1,6 +1,7 @@
 import './Output'
 import './MakeCommandCommand'
 import './TinkerCommand'
+import './Scheduler'
 import './ScheduleRunCommand'
 
 import program from 'commander'
@@ -9,10 +10,12 @@ export class Cli {
 	app = null
 	commands = [ ]
 	output = null
+	scheduler = null
 
 	constructor(app) {
 		this.app = app
 		this.output = new Output
+		this.scheduler = new Scheduler(this)
 		this.register(MakeCommandCommand)
 		this.register(TinkerCommand)
 		this.register(ScheduleRunCommand)
@@ -80,6 +83,10 @@ export class Cli {
 				this.commands.push(command)
 			}
 		}
+	}
+
+	schedule(value, args) {
+		return this.scheduler.create(value, args)
 	}
 
 }

--- a/src/Cli.js
+++ b/src/Cli.js
@@ -1,7 +1,7 @@
 import './Output'
 import './MakeCommandCommand'
 import './TinkerCommand'
-import './ScheduleCommand'
+import './ScheduleRunCommand'
 
 import program from 'commander'
 
@@ -15,7 +15,7 @@ export class Cli {
 		this.output = new Output
 		this.register(MakeCommandCommand)
 		this.register(TinkerCommand)
-		this.register(ScheduleCommand)
+		this.register(ScheduleRunCommand)
 	}
 
 	async run(args = process.argv) {

--- a/src/Command.js
+++ b/src/Command.js
@@ -182,7 +182,17 @@ export class Command {
 	}
 
 	registerSchedule() {
-		this.schedule().map(schedule => {
+		const schedules = this.schedule()
+
+		if(!schedules) {
+			schedules = [ ]
+		}
+
+		if(schedules instanceof SchedulerJob) {
+			schedules = [ schedules ]
+		}
+
+		schedules.map(schedule => {
 			this.success(this.name + ' has been scheduled to run next at: ' + schedule.nextOccurence())
 			schedule.start()
 		})

--- a/src/Command.js
+++ b/src/Command.js
@@ -196,7 +196,9 @@ export class Command {
 		}
 
 		if(!args) {
-			args = []
+			args = [ ]
+		} else {
+			args = [ ].concat(...args)
 		}
 
 		args.unshift(this.name)

--- a/src/Command.js
+++ b/src/Command.js
@@ -4,6 +4,7 @@ import './Scheduler'
 import cast from 'as-type'
 import chalk from 'chalk'
 import readline from 'readline'
+import ChildProcess from 'child_process'
 
 export class Command {
 	app = null
@@ -181,30 +182,28 @@ export class Command {
 	}
 
 	registerSchedule() {
-		return new Promise((resolve, reject) => {
-			this.schedule().then((scheduler) => {
-				this.success(this.name + ' has been scheduled to run next at: ' + scheduler.nextOccurence())
-				scheduler.start(() => {
-					this.execAsChildProcess().then((output) => {
-						this.info(output)
-					}).catch((err) => {
-						this.error(err)
-					})
+		return this.schedule().then((scheduler) => {
+			this.success(this.name + ' has been scheduled to run next at: ' + scheduler.nextOccurence())
+			scheduler.start(() => {
+				this.execAsChildProcess().then((output) => {
+					this.info(output)
+				}).catch((err) => {
+					this.error(err)
 				})
 			})
 		})
 	}
 
 	execAsChildProcess() {
-		const exec = require('child_process').exec
+		const exec = ChildProcess.exec
 
 		const options = {
 			env: process.env
 		}
 
-		return new Promise(async (resolve, reject) => {
-			await exec(process.env.CLI_BIN + ' ' + this.name, options, (err, stdout, stderr) => {
-				if (err instanceof Error) {
+		return new Promise((resolve, reject) => {
+			exec(process.env.CLI_BIN + ' ' + this.name, options, (err, stdout, stderr) => {
+				if(err instanceof Error) {
 					reject(err)
 				}
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -1,5 +1,4 @@
 import './AbortError'
-import './Scheduler'
 
 import cast from 'as-type'
 import chalk from 'chalk'
@@ -14,7 +13,6 @@ export class Command {
 	description = null
 	arguments = [ ]
 	options = { }
-	scheduler = null
 
 	compiledValues = {
 		arguments: { },
@@ -24,7 +22,6 @@ export class Command {
 	constructor(app, cli) {
 		this.app = app
 		this.cli = cli
-		this.scheduler = new Scheduler(this)
 	}
 
 	argument(name, fallback = null) {
@@ -174,27 +171,6 @@ export class Command {
 			}
 
 			process.exit(1)
-		})
-	}
-
-	schedule() {
-		return []
-	}
-
-	registerSchedule() {
-		const schedules = this.schedule()
-
-		if(!schedules) {
-			schedules = [ ]
-		}
-
-		if(schedules instanceof SchedulerJob) {
-			schedules = [ schedules ]
-		}
-
-		schedules.map(schedule => {
-			this.success(this.name + ' has been scheduled to run next at: ' + schedule.nextOccurence())
-			schedule.start()
 		})
 	}
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -178,33 +178,33 @@ export class Command {
 	}
 
 	schedule() {
-		return Promise.reject('Command does not implement schedule(): ' + this.name)
+		return []
 	}
 
 	registerSchedule() {
-		return this.schedule().then((scheduler) => {
-			this.success(this.name + ' has been scheduled to run next at: ' + scheduler.nextOccurence())
-			scheduler.start(() => {
-				this.execAsChildProcess().then((output) => {
-					this.info(output)
-				}).catch((err) => {
-					this.error(err)
-				})
-			})
+		this.schedule().map(schedule => {
+			this.success(this.name + ' has been scheduled to run next at: ' + schedule.nextOccurence())
+			schedule.start()
 		})
 	}
 
-	execAsChildProcess() {
-		const exec = ChildProcess.exec
+	execAsChildProcess(args) {
+		const execFile = ChildProcess.execFile
 
 		const options = {
 			env: process.env
 		}
 
+		if(!args) {
+			args = []
+		}
+
+		args.unshift(this.name)
+
 		return new Promise((resolve, reject) => {
-			exec(process.env.CLI_BIN + ' ' + this.name, options, (err, stdout, stderr) => {
+			execFile(process.env.CLI_BIN, args, options, (err, stdout, stderr) => {
 				if(err instanceof Error) {
-					reject(err)
+					return reject(err)
 				}
 
 				resolve(stdout)

--- a/src/ScheduleCommand.js
+++ b/src/ScheduleCommand.js
@@ -1,6 +1,6 @@
 import './Command'
 
-export class ScheduleCommand extends Command {
+export class ScheduleRunCommand extends Command {
 
 	name = 'schedule:run'
 	description = 'Starts the schedule daemon and executes commands as scheduled.'

--- a/src/ScheduleCommand.js
+++ b/src/ScheduleCommand.js
@@ -5,18 +5,12 @@ export class ScheduleCommand extends Command {
 	name = 'schedule:run'
 	description = 'Starts the schedule daemon and executes commands as scheduled.'
 
-	async run() {
+	run() {
 		this.info('Schedule daemon starting...')
 
-		const scheduled = []
+		const scheduled = this.cli.commands.map(command => command.registerSchedule())
 
-		for(let command of this.cli.commands) {
-			if(typeof(command.schedule) === 'function') {
-				scheduled.push(command.registerSchedule())
-			}
-		}
-
-		await Promise.all(scheduled)
+		return Promise.all(scheduled)
 	}
 
 }

--- a/src/ScheduleCommand.js
+++ b/src/ScheduleCommand.js
@@ -1,0 +1,22 @@
+import './Command'
+
+export class ScheduleCommand extends Command {
+
+	name = 'schedule:run'
+	description = 'Starts the schedule daemon and executes commands as scheduled.'
+
+	async run() {
+		this.info('Schedule daemon starting...')
+
+		const scheduled = []
+
+		for(var command of this.cli.commands) {
+			if(typeof(command.schedule) === 'function') {
+				scheduled.push(command.registerSchedule())
+			}
+		}
+
+		await Promise.all(scheduled)
+	}
+
+}

--- a/src/ScheduleCommand.js
+++ b/src/ScheduleCommand.js
@@ -10,7 +10,7 @@ export class ScheduleCommand extends Command {
 
 		const scheduled = []
 
-		for(var command of this.cli.commands) {
+		for(let command of this.cli.commands) {
 			if(typeof(command.schedule) === 'function') {
 				scheduled.push(command.registerSchedule())
 			}

--- a/src/ScheduleRunCommand.js
+++ b/src/ScheduleRunCommand.js
@@ -10,7 +10,7 @@ export class ScheduleRunCommand extends Command {
 
 		const scheduled = this.cli.commands.map(command => command.registerSchedule())
 
-		return Promise.all(scheduled)
+		return new Promise(() => {})
 	}
 
 }

--- a/src/ScheduleRunCommand.js
+++ b/src/ScheduleRunCommand.js
@@ -8,13 +8,7 @@ export class ScheduleRunCommand extends Command {
 	run() {
 		this.info('Schedule daemon starting...')
 
-		//const scheduled = this.cli.commands.map(command => command.registerSchedule())
-		const scheduled = []
-		for(const command of this.cli.commands) {
-			if(typeof command.schedule === 'function') {
-				scheduled.push(command.registerSchedule())
-			}
-		}
+		const scheduled = this.cli.commands.map(command => command.registerSchedule())
 
 		return new Promise(() => {})
 	}

--- a/src/ScheduleRunCommand.js
+++ b/src/ScheduleRunCommand.js
@@ -8,7 +8,13 @@ export class ScheduleRunCommand extends Command {
 	run() {
 		this.info('Schedule daemon starting...')
 
-		const scheduled = this.cli.commands.map(command => command.registerSchedule())
+		//const scheduled = this.cli.commands.map(command => command.registerSchedule())
+		const scheduled = []
+		for(const command of this.cli.commands) {
+			if(typeof command.schedule === 'function') {
+				scheduled.push(command.registerSchedule())
+			}
+		}
 
 		return new Promise(() => {})
 	}

--- a/src/ScheduleRunCommand.js
+++ b/src/ScheduleRunCommand.js
@@ -8,7 +8,7 @@ export class ScheduleRunCommand extends Command {
 	run() {
 		this.info('Schedule daemon starting...')
 
-		const scheduled = this.cli.commands.map(command => command.registerSchedule())
+		this.cli.scheduler.start()
 
 		return new Promise(() => {})
 	}

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -1,0 +1,144 @@
+import later from 'later'
+
+export class Scheduler {
+
+	command = null
+	provider = later
+
+	schedule = null
+	allowOverlapping = false
+	_running = false
+
+	constructor(command) {
+		this.command = command
+	}
+
+	start(job) {
+		return new Promise((resolve, reject) => {
+			if(!this.schedule) {
+				reject('No schedule has been defined.')
+			}
+
+			const interval = this.provider.setInterval(() => {
+				if(this._running && !this.allowOverlapping) {
+					return false
+				}
+
+				this._running = true
+
+				job()
+
+				this._running = false
+			}, this.schedule)
+		})
+	}
+
+	cron(str) {
+		return this.setSchedule(this.provider.parse.cron(str))
+	}
+
+	everyMinute() {
+		return this.setSchedule(this.provider.parse.recur().every(1).minute())
+	}
+
+	everyFiveMinutes() {
+		return this.setSchedule(this.provider.parse.recur().every(5).minute())
+	}
+
+	everyTenMinutes() {
+		return this.setSchedule(this.provider.parse.recur().every(10).minute())
+	}
+
+	everyThirtyMinutes() {
+		return this.setSchedule(this.provider.parse.recur().every(30).minute())
+	}
+
+	hourly() {
+		return this.setSchedule(this.provider.parse.recur().every(1).hour())
+	}
+
+	daily() {
+		return this.setSchedule(this.provider.parse.recur().on('00:00:00').time())
+	}
+
+	dailyAt(time) {
+		return this.setSchedule(this.provider.parse.recur().on(time).time())
+	}
+
+	twiceDaily(time1, time2) {
+		return this.setSchedule(this.provider.parse.recur().on(time1, time2).time())
+	}
+
+	weekly() {
+		return this.setSchedule(this.provider.parse.recur().on(1).dayOfWeek())
+	}
+
+	monthly() {
+		return this.setSchedule(this.provider.parse.recur().on(1).dayOfMonth())
+	}
+
+	monthlyOn(day, time) {
+		return this.setSchedule(this.provider.parse.recur().on(day).dayOfMonth().on(time).time())
+	}
+
+	timezone(tz) {
+		return new Promise(async (resolve, reject) => {
+			await this.provider.date.timezone(tz)
+			return resolve(this)
+		})
+	}
+
+	UTC() {
+		return new Promise(async (resolve, reject) => {
+			await this.provider.date.UTC()
+			return resolve(this)
+		})
+	}
+
+	localtime() {
+		return new Promise(async (resolve, reject) => {
+			await this.provider.date.localtime()
+			return resolve(this)
+		})
+	}
+
+	withOverlapping() {
+		return new Promise((resolve, reject) => {
+			this.allowOverlapping = true
+			return resolve(this)
+		})
+	}
+
+	withoutOverlapping() {
+		return new Promise((resolve, reject) => {
+			this.allowOverlapping = false
+			return resolve(this)
+		})
+	}
+
+	nextOccurence() {
+		if(!this.schedule) {
+			return null
+		}
+
+		const schedule = this.provider.schedule(this.schedule).next(1)
+
+		if(schedule) {
+			return schedule
+		}
+
+		return null
+	}
+
+	setSchedule(schedule) {
+		return new Promise((resolve, reject) => {
+			try {
+				this.schedule = schedule
+			} catch(err) {
+				return reject(err)
+			}
+
+			return resolve(this)
+		})
+	}
+}

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -7,17 +7,17 @@ export class Scheduler {
 	provider = later
 	cli = null
 
-	jobs = []
+	jobs = [ ]
 
-	constructor(runCommand) {
-		this.cli = runCommand.cli
+	constructor(cli) {
+		this.cli = cli
 	}
 
 	start() {
 		return new Promise((resolve, reject) => {
 			this.jobs.map((job) => {
 				if(!job.schedule) {
-					return reject('Missing a job schedule.')
+					return reject('Job is missing a schedule.')
 				}
 
 				job.start()
@@ -25,29 +25,53 @@ export class Scheduler {
 		})
 	}
 
-	command(cmd, args) {
-		cmdArray = []
-
-		if(cmd.indexOf(' ') > 0) {
-			cmdArray = cmd.trim().split(' ')
-			cmd = cmdArray.shift()
-			args = [ ].concat(cmdArray, args)
+	create(value, args) {
+		if(typeof value === 'function' && value.name.endsWith('Command')) {
+			return this.className(value, args)
 		}
 
-		return this.addJob('command', {
-			command: cmd,
+		if(typeof value === 'string') {
+			return this.name(value, args)
+		}
+
+		if(typeof value === 'function') {
+			return this.call(value, args)
+		}
+
+		throw new Error('Invalid command definition used to create schedule job. Must use: class name, cmd line string or closure.')
+	}
+
+	className(className, args) {
+		return this.addJob('className', {
+			className: className,
 			args: args
 		})
 	}
 
-	call(closure) {
+	name(name, args) {
+		let cmd = [ ]
+
+		if(name.indexOf(' ') > 0) {
+			cmd = name.trim().split(' ')
+			name = cmd.shift()
+			args = [ ].concat(cmd, args)
+		}
+
+		return this.addJob('name', {
+			name: name,
+			args: args
+		})
+	}
+
+	call(closure, args) {
 		return this.addJob('closure', {
-			closure: closure
+			closure: closure,
+			args: args
 		})
 	}
 
 	addJob(type, options) {
-		const job = new SchedulerJob(this, type, options)
+		const job = new SchedulerJob(this.cli, type, options)
 		this.jobs.push(job)
 		return job
 	}

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -26,6 +26,14 @@ export class Scheduler {
 	}
 
 	command(cmd, args) {
+		cmdArray = []
+
+		if(cmd.indexOf(' ') > 0) {
+			cmdArray = cmd.trim().split(' ')
+			cmd = cmdArray.shift()
+			args = [ ].concat(cmdArray, args)
+		}
+
 		return this.addJob('command', {
 			command: cmd,
 			args: args

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -1,144 +1,47 @@
+import './SchedulerJob'
+
 import later from 'later'
 
 export class Scheduler {
 
-	command = null
 	provider = later
+	cli = null
 
-	schedule = null
-	allowOverlapping = false
-	_running = false
+	jobs = []
 
-	constructor(command) {
-		this.command = command
+	constructor(runCommand) {
+		this.cli = runCommand.cli
 	}
 
-	start(job) {
+	start() {
 		return new Promise((resolve, reject) => {
-			if(!this.schedule) {
-				return reject('No schedule has been defined.')
-			}
-
-			this.provider.setInterval(() => {
-				if(this._running && !this.allowOverlapping) {
-					return false
+			this.jobs.map((job) => {
+				if(!job.schedule) {
+					return reject('Missing a job schedule.')
 				}
 
-				this._running = true
-
-				job()
-
-				this._running = false
-			}, this.schedule)
+				job.start()
+			})
 		})
 	}
 
-	cron(str) {
-		return this.setSchedule(this.provider.parse.cron(str))
-	}
-
-	everyMinute() {
-		return this.setSchedule(this.provider.parse.recur().every(1).minute())
-	}
-
-	everyFiveMinutes() {
-		return this.setSchedule(this.provider.parse.recur().every(5).minute())
-	}
-
-	everyTenMinutes() {
-		return this.setSchedule(this.provider.parse.recur().every(10).minute())
-	}
-
-	everyThirtyMinutes() {
-		return this.setSchedule(this.provider.parse.recur().every(30).minute())
-	}
-
-	hourly() {
-		return this.setSchedule(this.provider.parse.recur().every(1).hour())
-	}
-
-	daily() {
-		return this.setSchedule(this.provider.parse.recur().on('00:00:00').time())
-	}
-
-	dailyAt(time) {
-		return this.setSchedule(this.provider.parse.recur().on(time).time())
-	}
-
-	twiceDaily(time1, time2) {
-		return this.setSchedule(this.provider.parse.recur().on(time1, time2).time())
-	}
-
-	weekly() {
-		return this.setSchedule(this.provider.parse.recur().on(1).dayOfWeek())
-	}
-
-	monthly() {
-		return this.setSchedule(this.provider.parse.recur().on(1).dayOfMonth())
-	}
-
-	monthlyOn(day, time) {
-		return this.setSchedule(this.provider.parse.recur().on(day).dayOfMonth().on(time).time())
-	}
-
-	timezone(tz) {
-		return new Promise(async (resolve) => {
-			await this.provider.date.timezone(tz)
-			return resolve(this)
+	command(cmd, args) {
+		return this.addJob('command', {
+			command: cmd,
+			args: args
 		})
 	}
 
-	UTC() {
-		return new Promise(async (resolve) => {
-			await this.provider.date.UTC()
-			return resolve(this)
+	call(closure) {
+		return this.addJob('closure', {
+			closure: closure
 		})
 	}
 
-	localtime() {
-		return new Promise(async (resolve) => {
-			await this.provider.date.localtime()
-			return resolve(this)
-		})
+	addJob(type, options) {
+		const job = new SchedulerJob(this, type, options)
+		this.jobs.push(job)
+		return job
 	}
 
-	withOverlapping() {
-		return new Promise((resolve) => {
-			this.allowOverlapping = true
-			return resolve(this)
-		})
-	}
-
-	withoutOverlapping() {
-		return new Promise((resolve) => {
-			this.allowOverlapping = false
-			return resolve(this)
-		})
-	}
-
-	nextOccurence() {
-		if(!this.schedule) {
-			return null
-		}
-
-		const schedule = this.provider.schedule(this.schedule).next(1)
-
-		if(schedule) {
-			return schedule
-		}
-
-		return null
-	}
-
-	setSchedule(schedule) {
-		return new Promise((resolve, reject) => {
-			try {
-				this.schedule = schedule
-			} catch(err) {
-				return reject(err)
-			}
-
-			return resolve(this)
-		})
-	}
 }

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -16,10 +16,10 @@ export class Scheduler {
 	start(job) {
 		return new Promise((resolve, reject) => {
 			if(!this.schedule) {
-				reject('No schedule has been defined.')
+				return reject('No schedule has been defined.')
 			}
 
-			const interval = this.provider.setInterval(() => {
+			this.provider.setInterval(() => {
 				if(this._running && !this.allowOverlapping) {
 					return false
 				}
@@ -82,35 +82,35 @@ export class Scheduler {
 	}
 
 	timezone(tz) {
-		return new Promise(async (resolve, reject) => {
+		return new Promise(async (resolve) => {
 			await this.provider.date.timezone(tz)
 			return resolve(this)
 		})
 	}
 
 	UTC() {
-		return new Promise(async (resolve, reject) => {
+		return new Promise(async (resolve) => {
 			await this.provider.date.UTC()
 			return resolve(this)
 		})
 	}
 
 	localtime() {
-		return new Promise(async (resolve, reject) => {
+		return new Promise(async (resolve) => {
 			await this.provider.date.localtime()
 			return resolve(this)
 		})
 	}
 
 	withOverlapping() {
-		return new Promise((resolve, reject) => {
+		return new Promise((resolve) => {
 			this.allowOverlapping = true
 			return resolve(this)
 		})
 	}
 
 	withoutOverlapping() {
-		return new Promise((resolve, reject) => {
+		return new Promise((resolve) => {
 			this.allowOverlapping = false
 			return resolve(this)
 		})

--- a/src/SchedulerJob.js
+++ b/src/SchedulerJob.js
@@ -1,0 +1,146 @@
+import later from 'later'
+
+export class SchedulerJob {
+
+	provider = null
+	scheduler = null
+	cli = false
+
+	type = null
+	options = null
+
+	isRunning = false
+	allowOverlapping = false
+
+	constructor(scheduler, type, options) {
+		this.provider = later
+		this.cli = scheduler.cli
+		this.type = type
+		this.options = options
+	}
+
+	start() {
+		this.provider.setInterval(() => {
+			if(this.isRunning && !this.allowOverlapping) {
+				return false
+			}
+
+			this.isRunning = true
+
+			if(this.type === 'command') {
+				for(const command of this.cli.commands) {
+					if(command.name === this.options.command) {
+						command.execAsChildProcess(this.options.args).then((output) => {
+							this.cli.output.info(output)
+						}).catch((err) => {
+							this.cli.output.error(err)
+						})
+					}
+				}
+			}
+
+			if(this.type === 'closure') {
+				this.options.closure()
+			}
+
+			this.isRunning = false
+		}, this.schedule)
+	}
+
+	cron(str) {
+		this.schedule = this.provider.parse.cron(str)
+		return this
+	}
+
+	everyMinute() {
+		this.schedule = this.provider.parse.recur().every(1).minute()
+		return this
+	}
+
+	everyFiveMinutes() {
+		this.schedule = this.provider.parse.recur().every(5).minute()
+		return this
+	}
+
+	everyTenMinutes() {
+		this.schedule = this.provider.parse.recur().every(10).minute()
+		return this
+	}
+
+	everyThirtyMinutes() {
+		this.schedule = this.provider.parse.recur().every(30).minute()
+		return this
+	}
+
+	hourly() {
+		this.schedule = this.provider.parse.recur().every(1).hour()
+		return this
+	}
+
+	daily() {
+		this.schedule = this.provider.parse.recur().on('00:00:00').time()
+		return this
+	}
+
+	dailyAt(time) {
+		this.schedule = this.provider.parse.recur().on(time).time()
+		return this
+	}
+
+	twiceDaily(time1, time2) {
+		this.schedule = this.provider.parse.recur().on(time1, time2).time()
+		return this
+	}
+
+	weekly() {
+		this.schedule = this.provider.parse.recur().on(1).dayOfWeek()
+		return this
+	}
+
+	monthly() {
+		this.schedule = this.provider.parse.recur().on(1).dayOfMonth()
+		return this
+	}
+
+	monthlyOn(day, time) {
+		this.schedule = this.provider.parse.recur().on(day).dayOfMonth().on(time).time()
+		return this
+	}
+
+	timezone(tz) {
+		this.provider.date.timezone(tz)
+	}
+
+	UTC() {
+		this.provider.date.UTC()
+	}
+
+	localtime() {
+		this.provider.date.localtime()
+	}
+
+	withOverlapping() {
+		this.allowOverlapping = true
+		return this
+	}
+
+	withoutOverlapping() {
+		this.allowOverlapping = false
+		return this
+	}
+
+	nextOccurence() {
+		if(!this.schedule) {
+			return null
+		}
+
+		const schedule = this.provider.schedule(this.schedule).next(1)
+
+		if(schedule) {
+			return schedule
+		}
+
+		return null
+	}
+
+}


### PR DESCRIPTION
Added a new built in command called `schedule:run` that looks for registered app commands that have a `schedule()` function and attempts to schedule them to run.

Scheduling a command is as easy as adding a `schedule()` method to your command. It should look something like this:

```
schedule() {
    return this.scheduler.everyMinute()
}
```
